### PR TITLE
Add pendingUrl to Tab type definition

### DIFF
--- a/lib/tabs.d.ts
+++ b/lib/tabs.d.ts
@@ -135,6 +135,12 @@ export declare namespace Tabs {
         url?: string;
 
         /**
+         * The URL the tab is navigating to, before it has committed. This property is only present if the extension's manifest includes the "tabs" permission and there is a pending navigation.
+         * Optional.
+         */
+        pendingUrl?: string;
+
+        /**
          * The title of the tab. This property is only present if the extension's manifest includes the <code>"tabs"</code> permission.
          * Optional.
          */


### PR DESCRIPTION
`pendingUrl` was introduced since Chrome 79 https://developer.chrome.com/extensions/tabs#property-Tab-pendingUrl

It should be in the `Tab` type definition here as well.