### PR TITLE
Permissions.remove to return boolean not void

### DIFF
--- a/fixes/permissions.json
+++ b/fixes/permissions.json
@@ -1,0 +1,3 @@
+{
+  "functions.%remove.parameters.%callback.parameters.+[]": [{ "name": "removed", "type": "boolean" }]
+}

--- a/lib/manifest.d.ts
+++ b/lib/manifest.d.ts
@@ -259,13 +259,13 @@ export declare namespace Manifest {
 
     type OptionalPermissionNoPrompt = "idle" | "cookies" | "menus.overrideContext" | "search" | "activeTab" | "webRequest" | "webRequestBlocking";
 
-    type OptionalPermission = OptionalPermissionNoPrompt | "clipboardRead" | "clipboardWrite" | "geolocation" | "notifications" | "bookmarks" | "browserSettings" | "browsingData" | "devtools" | "downloads" | "downloads.open" | "find" | "history" | "management" | "pkcs11" | "privacy" | "proxy" | "sessions" | "tabs" | "tabHide" | "topSites" | "webNavigation";
+    type OptionalPermission = OptionalPermissionNoPrompt | "clipboardRead" | "clipboardWrite" | "geolocation" | "notifications" | "bookmarks" | "browserSettings" | "browsingData" | "devtools" | "downloads" | "downloads.open" | "find" | "history" | "management" | "pkcs11" | "privacy" | "proxy" | "nativeMessaging" | "sessions" | "tabs" | "tabHide" | "topSites" | "webNavigation";
 
     type OptionalPermissionOrOrigin = OptionalPermission | MatchPattern;
 
     type PermissionNoPrompt = OptionalPermission | "alarms" | "mozillaAddons" | "storage" | "unlimitedStorage" | "activityLog" | "captivePortal" | "contextualIdentities" | "dns" | "geckoProfiler" | "identity" | "menus" | "contextMenus" | "networkStatus" | "normandyAddonStudy" | "theme" | "urlbar";
 
-    type Permission = PermissionNoPrompt | OptionalPermission | string | "nativeMessaging";
+    type Permission = PermissionNoPrompt | OptionalPermission | string;
 
     type PermissionOrOrigin = Permission | MatchPattern;
 

--- a/lib/permissions.d.ts
+++ b/lib/permissions.d.ts
@@ -63,9 +63,9 @@ export declare namespace Permissions {
          * Relinquish the given permissions.
          *
          * @param permissions
-         * @returns Promise<void>
+         * @returns Promise<boolean>
          */
-        remove(permissions: Permissions): Promise<void>;
+        remove(permissions: Permissions): Promise<boolean>;
 
         /**
          * Fired when the extension acquires new permissions.

--- a/schemas/runtime.json
+++ b/schemas/runtime.json
@@ -7,7 +7,7 @@
     "namespace": "manifest",
     "types": [
       {
-        "$extend": "Permission",
+        "$extend": "OptionalPermission",
         "choices": [{
           "type": "string",
           "enum": [


### PR DESCRIPTION
Interesting how both Mozilla and Chrome states that `Permissions.remove()` should return the removal result as a boolean but it isn't in the schema.

This PR adds a fix for that.  Hopefully the new fix file is inline with how it should be added.

There seem to be a schema update upstream that has been included here as well.

Signed-off-by: Kenneth T <kennethtran93@users.noreply.github.com>