### PR TITLE
Fix return type of browser.dns.resolve()

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ You might have noticed that some generated code is wrong.. Since I don't use the
 
 This file should give you a quick introduction. It won't cover everything.
 
-Sadly, there is official documentation for the schema .json files that I know of. I suggest having a look at `src/helpers/types.ts`, which documents structure of the schema.json files as I deducted them from reading them.
+Sadly, there is no official documentation for the schema .json files that I know of. I suggest having a look at `src/helpers/types.ts`, which documents structure of the schema.json files as I deducted them from reading them.
 
 ## Build commands:
 

--- a/fixes/dns.json
+++ b/fixes/dns.json
@@ -1,0 +1,3 @@
+{
+  "functions.%resolve.!fixAsync": "result:DNSRecord"
+}

--- a/lib/dns.d.ts
+++ b/lib/dns.d.ts
@@ -37,7 +37,8 @@ export declare namespace Dns {
          *
          * @param hostname
          * @param flags Optional.
+         * @returns Promise<DNSRecord>
          */
-        resolve(hostname: string, flags?: ResolveFlags): void;
+        resolve(hostname: string, flags?: ResolveFlags): Promise<DNSRecord>;
     }
 }

--- a/schemas/runtime.json
+++ b/schemas/runtime.json
@@ -7,7 +7,7 @@
     "namespace": "manifest",
     "types": [
       {
-        "$extend": "Permission",
+        "$extend": "OptionalPermission",
         "choices": [{
           "type": "string",
           "enum": [

--- a/src/fixes/index.ts
+++ b/src/fixes/index.ts
@@ -20,7 +20,6 @@ export const fixes: SchemaVisitorFactory[] = [
     applyExtensionNamespace,
     applyEarlyJsonFixes,
     removeUnusedAdditionalProperties,
-    removeUnsupported,
     cleanupRefs,
     applyJsonFixes,
     extractInlineContent,


### PR DESCRIPTION
This PR introduces a fix to [`browser.dns.resolve()`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/dns/resolve) where `void` return type had previously been incorrectly inferred.

https://github.com/Lusito/webextension-polyfill-ts/blob/ae930cb8b859d90236502aa2a70bc02a9ee322aa/lib/dns.d.ts#L33-L42

I've also included a few small drive-by changes:
- Updated contents of `schemas/runtime.json` with the most recent downloaded version.
- Removed duplicate call to `removeUnsupported` in `src/fixes/index.ts`.

