### PR TITLE
Remove runtime dependency on webextension-polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Web-Extension Polyfill for TypeScript
 
 This is a TypeScript ready "wrapper" for the [WebExtension browser API Polyfill](https://github.com/mozilla/webextension-polyfill) by Mozilla.
-* It does include webextension-polyfill, so no need to manually add it.
+* It does not include webextension-polyfill, but it is required as a peer dependency. You need to manually install and load/execute it where necessary.
 * It is generated from these mozilla schema (.json) files:
   * [toolkit](https://hg.mozilla.org/integration/autoland/raw-file/tip/toolkit/components/extensions/schemas/)
   * [browser](https://hg.mozilla.org/integration/autoland/raw-file/tip/browser/components/extensions/schemas/)
@@ -11,11 +11,11 @@ This guide assumes you are building a web-extension using npm and webpack, parce
 If you are looking for an example use-case, check out the development branch of my web-extension [Forget Me Not](https://github.com/lusito/forget-me-not/tree/develop).
 
 * `npm install --save-dev webextension-polyfill-ts`
-* `import { browser } from "webextension-polyfill-ts";`
-  * Use this to access the browser API.
-  * If the current environment does not supply a global window object, the exported browser object will be a dummy object, which you can use for unit tests.
+* `import "webextension-polyfill-ts";`
+  * Adds types for the global `browser` object.
+  * Use `browser` as usual to access the browser API.
 
-If you want to use the exported types in your code, simply import them like this:
+If you want to use specific exported types in your code, simply import them like this:
 ```typescript
 import { Cookies } from "webextension-polyfill-ts";
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -167,4 +167,6 @@ export interface Browser {
     windows: Windows.Static;
 }
 
-export declare const browser: Browser;
+declare global {
+    const browser: Browser;
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,0 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-
-exports.browser = require("webextension-polyfill");

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,6 @@
     "": {
       "version": "0.25.0",
       "license": "Zlib",
-      "dependencies": {
-        "webextension-polyfill": "^0.7.0"
-      },
       "devDependencies": {
         "@lusito/eslint-config": "^1.5.0",
         "@lusito/prettier-config": "^1.5.0",
@@ -21,6 +18,9 @@
         "sort-package-json": "^1.48.1",
         "ts-node": "^9.1.1",
         "typescript": "^4.1.5"
+      },
+      "peerDependencies": {
+        "webextension-polyfill": "^0.7.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4684,7 +4684,8 @@
     "node_modules/webextension-polyfill": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.7.0.tgz",
-      "integrity": "sha512-su48BkMLxqzTTvPSE1eWxKToPS2Tv5DLGxKexLEVpwFd6Po6N8hhSLIvG6acPAg7qERoEaDL+Y5HQJeJeml5Aw=="
+      "integrity": "sha512-su48BkMLxqzTTvPSE1eWxKToPS2Tv5DLGxKexLEVpwFd6Po6N8hhSLIvG6acPAg7qERoEaDL+Y5HQJeJeml5Aw==",
+      "peer": true
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -8472,7 +8473,8 @@
     "webextension-polyfill": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.7.0.tgz",
-      "integrity": "sha512-su48BkMLxqzTTvPSE1eWxKToPS2Tv5DLGxKexLEVpwFd6Po6N8hhSLIvG6acPAg7qERoEaDL+Y5HQJeJeml5Aw=="
+      "integrity": "sha512-su48BkMLxqzTTvPSE1eWxKToPS2Tv5DLGxKexLEVpwFd6Po6N8hhSLIvG6acPAg7qERoEaDL+Y5HQJeJeml5Aw==",
+      "peer": true
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -38,9 +38,6 @@
     "validate:lib": "tsc -p tsconfig-lib.json",
     "validate:schemas": "ts-node src/validate.ts"
   },
-  "dependencies": {
-    "webextension-polyfill": "^0.7.0"
-  },
   "devDependencies": {
     "@lusito/eslint-config": "^1.5.0",
     "@lusito/prettier-config": "^1.5.0",
@@ -52,5 +49,8 @@
     "sort-package-json": "^1.48.1",
     "ts-node": "^9.1.1",
     "typescript": "^4.1.5"
+  },
+  "peerDependencies": {
+    "webextension-polyfill": "^0.7.0"
   }
 }

--- a/src/build.ts
+++ b/src/build.ts
@@ -335,7 +335,9 @@ function writeIndexFile(namespaces: ImportedNamespace[]) {
     });
     writer.end("}");
 
-    writer.code("export declare const browser: Browser;");
+    writer.begin("declare global {");
+    writer.code("const browser: Browser;");
+    writer.end("}");
     writer.emptyLine();
     fs.writeFileSync("lib/index.d.ts", writer.toString());
 }


### PR DESCRIPTION
- Removes the `browser` property, which at runtime re-exported `webextension-polyfill`.
  - This avoids loading the browser extension-dependent code in `webextension-polyfill` at runtime, since it throws an error in other environments such as tests executed in Node.js.
- Defines a global `browser` of type `Browser`.
  - Instead of importing the `browser` property, use `import "webextension-polyfill-ts";` to enable the typed global `browser` object.
  - This is compile-time support for Typescript. It does not load/execute the `webextension-polyfill` runtime polyfill.
- Made `webextension-polyfill` a peer depedency
  - Other packages have to install and load/execute `webextension-polyfill` themselves.

---

- Only tested this change on a local project, but it worked right away after removing the old `browser` imports.
- Shipping Typescript types is tricky, so submitting this pull request for public testing and feedback.
- Longer explanation and context comes in a follow-up comment.