### PR TITLE
Fix global type documentation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ I don't recommend that use-case, but if you are looking for types in this scenar
 import type { Browser } from "webextension-polyfill";
 
 declare global {
-    const browser: Browser.Browser;
+    const browser: Browser;
 }
 ```
 


### PR DESCRIPTION
I'm getting an error here, but `const browser: Browser` seems to work

![gif](https://user-images.githubusercontent.com/1402241/157642551-f2b340c1-0c42-4d96-9955-f4acdf798bb3.gif)
