### PR TITLE
fix #78: getMessage string substitutions

### DIFF
--- a/fixes/i18n.json
+++ b/fixes/i18n.json
@@ -1,0 +1,1 @@
+{ "functions.%getMessage.parameters.%substitutions.type":  "string[] | string" }

--- a/out/namespaces/i18n.d.ts
+++ b/out/namespaces/i18n.d.ts
@@ -62,7 +62,7 @@ export namespace I18n {
          * @param substitutions Optional. Substitution strings, if the message requires any.
          * @returns Message localized for current locale.
          */
-        getMessage(messageName: string, substitutions?: any): string;
+        getMessage(messageName: string, substitutions?: string[] | string): string;
 
         /**
          * Gets the browser UI language of the browser. This is different from $(ref:i18n.getAcceptLanguages)


### PR DESCRIPTION
Fixes #78  by declaring the type of getMessage substitutions parameter as string or array of strings

https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/i18n/getMessage#parameters
https://developer.chrome.com/docs/extensions/reference/i18n/#method-getMessage