### PR TITLE
fix: remove definition of `hasListeners` not available in Firefox

### DIFF
--- a/fixes/events.json
+++ b/fixes/events.json
@@ -5,5 +5,6 @@
       "type": "any[]",
       "description": "Further parameters, depending on the event."
     }
-  ]
+  ],
+  "types.$Event.functions.%hasListeners": null
 }

--- a/out/namespaces/events.d.ts
+++ b/out/namespaces/events.d.ts
@@ -68,11 +68,6 @@ export namespace Events {
          * @returns True if <em>callback</em> is registered to the event.
          */
         hasListener(callback: T): boolean;
-
-        /**
-         * @returns True if any event listeners are registered to the event.
-         */
-        hasListeners(): boolean;
     }
 
     /**


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage#syntax `port.onMessage` doesn't have `hasListeners` method, e.g. it does not exists in Firefox, but it is available in Chrome. So, we accidentally run into this compatibility issue, to avoid this in the future I propose to remove the definition of `hasListeners`.

Reproduction in content script
```js
import browser from 'webextension-polyfill';

const port = browser.runtime.connect();
console.log(port.onMessage.hasListeners());
```
would throw an exception "TypeError: port.onMessage.hasListeners is not a function" in Forefox@108.0.2

This PR is supported by the Æternity Crypto Foundation