### PR TITLE
Add "admin" to ExtensionInstallType

### DIFF
--- a/fixes/management.json
+++ b/fixes/management.json
@@ -1,0 +1,5 @@
+{
+    "types.$ExtensionInstallType.enum.+[]": [
+        "admin"
+    ]
+}

--- a/out/namespaces/management.d.ts
+++ b/out/namespaces/management.d.ts
@@ -49,7 +49,7 @@ export namespace Management {
      * : The extension was installed by other software on the machine,<br><var>other</var>
      * : The extension was installed by other means.
      */
-    type ExtensionInstallType = "development" | "normal" | "sideload" | "other";
+    type ExtensionInstallType = "development" | "normal" | "sideload" | "other" | "admin";
 
     /**
      * Information about an installed extension.


### PR DESCRIPTION
This indicates that the extension was installed because of an administrative policy. This is documented [on mdn](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/management/ExtensionInfo) and also [supported by chrome](https://developer.chrome.com/docs/extensions/reference/api/management#type-ExtensionInstallType).  