### PR TITLE
add back support for getBytesInUse

### DIFF
--- a/out/namespaces/storage.d.ts
+++ b/out/namespaces/storage.d.ts
@@ -34,6 +34,16 @@ export namespace Storage {
         get(keys?: null | string | string[] | Record<string, unknown>): Promise<Record<string, unknown>>;
 
         /**
+         * Gets the amount of space (in bytes) being used by one or more items.
+         *
+         * @param keys Optional. A single key or list of keys to get the total usage for. An empty list will return 0.
+         * Pass in <code>null</code> to get the total usage of all of storage.
+         * @returns Callback with the amount of space being used by storage, or on failure (in which case $(ref:runtime.lastError)
+         * will be set).
+         */
+        getBytesInUse(keys?: string | string[]): Promise<number>;
+
+        /**
          * Sets multiple items.
          *
          * @param items <p>An object which gives each key/value pair to update storage with. Any other key/value pairs in storage

--- a/schemas/storage.json
+++ b/schemas/storage.json
@@ -63,7 +63,6 @@
           },
           {
             "name": "getBytesInUse",
-            "unsupported": true,
             "type": "function",
             "description": "Gets the amount of space (in bytes) being used by one or more items.",
             "async": "callback",


### PR DESCRIPTION
Type information for storage `getBytesInUse` does not exist except for storage `session` and `local`, but is there for `sync`.
However according to MDN doc, it is supported for `session` with `local` support blocked because of an issue.

The documentation still exists for `local`  https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/local#methods. So it seems their intent is there.

If we look on the chrome side, it is supported for all 4 storage types and type information (@types/chrome) is included for all 4 as well documentation support (See https://developer.chrome.com/docs/extensions/reference/api/storage#type-StorageArea).

It is included in mozilla/webextension-polyfill itself https://github.com/mozilla/webextension-polyfill/blob/6a42cbeaf637ba3f1283bdcdd657afd06454ca55/api-metadata.json#L480

So given all this I don't see why we should not support the type information any longer.