### PR TITLE
fix: Address a number of unfixed "async": true in various places.

### DIFF
--- a/fixes/action.json
+++ b/fixes/action.json
@@ -1,4 +1,6 @@
 {
+  "functions.%setBadgeTextColor.!fixAsync": null,
+  "functions.%getBadgeTextColor.!fixAsync": "badgeTextColor:ColorArray",
   "functions.%isEnabled.!fixAsync": "enabled:boolean",
   "functions.%openPopup.!fixAsync": null
 }

--- a/fixes/captivePortal.json
+++ b/fixes/captivePortal.json
@@ -1,0 +1,4 @@
+{
+    "functions.%getState.!fixAsync": "state:\"unknown\" | \"not_captive\" | \"unlocked_portal\" | \"locked_portal\"",
+    "functions.%getLastChecked.!fixAsync": "state:number"
+}

--- a/fixes/contextualIdentities.json
+++ b/fixes/contextualIdentities.json
@@ -3,5 +3,6 @@
   "functions.%query.!fixAsync": "contextualIdentity:ContextualIdentity[]",
   "functions.%create.!fixAsync": "contextualIdentity:ContextualIdentity",
   "functions.%update.!fixAsync": "contextualIdentity:ContextualIdentity",
+  "functions.%move.!fixAsync": null,
   "functions.%remove.!fixAsync": "contextualIdentity:ContextualIdentity"
 }

--- a/fixes/devtools.panels.json
+++ b/fixes/devtools.panels.json
@@ -1,5 +1,6 @@
 {
   "types.$ExtensionPanel.events.%onShown.parameters.%window.type": "Window",
   "types.$ExtensionSidebarPane.events.%onShown.parameters.%window.type": "Window",
-  "types.$ExtensionSidebarPane.functions.%setObject.parameters.%jsonObject.type": "string | unknown[] | Record<string, unknown>"
+  "types.$ExtensionSidebarPane.functions.%setObject.parameters.%jsonObject.type": "string | unknown[] | Record<string, unknown>",
+  "types.$ExtensionSidebarPane.functions.%setPage.!fixAsync": null
 }

--- a/fixes/search.json
+++ b/fixes/search.json
@@ -3,5 +3,6 @@
     "type": "Promise<SearchEngine[]>",
     "optional": true,
     "description": "A Promise that will be fulfilled with an array of search engine objects."
-  }
+  },
+  "functions.%search.!fixAsync": null
 }

--- a/fixes/sidebarAction.json
+++ b/fixes/sidebarAction.json
@@ -6,5 +6,6 @@
   "functions.%getPanel.!fixAsync": "url:string",
   "functions.%open.!fixAsync": null,
   "functions.%close.!fixAsync": null,
+  "functions.%toggle.!fixAsync": null,
   "functions.%isOpen.!fixAsync": "open:boolean"
 }

--- a/fixes/tabs.json
+++ b/fixes/tabs.json
@@ -4,6 +4,7 @@
   "functions.%executeScript.parameters.%callback.parameters.%result.optional": false,
   "functions.%getCurrent.parameters.%callback.parameters.%tab.optional": false,
   "functions.%update.parameters.%callback.parameters.%tab.optional": false,
+  "functions.%warmup.!fixAsync": null,
   "functions.%discard.!fixAsync": null,
   "functions.%toggleReaderMode.!fixAsync": null,
   "functions.%captureTab.!fixAsync": "dataUrl:string",

--- a/fixes/userScripts.json
+++ b/fixes/userScripts.json
@@ -1,3 +1,4 @@
 {
+  "functions.%register.parameters.%callback.parameters.%legacyRegisteredUserScript.properties.unregister.!fixAsync": null,
   "functions.%update.parameters.%scripts.items.$import": "Omit<RegisteredUserScript, \"js\">"
 }

--- a/out/namespaces/action.d.ts
+++ b/out/namespaces/action.d.ts
@@ -196,12 +196,12 @@ export namespace Action {
         /**
          * Sets the text color for the badge.
          */
-        setBadgeTextColor(details: SetBadgeTextColorDetailsType): void;
+        setBadgeTextColor(details: SetBadgeTextColorDetailsType): Promise<void>;
 
         /**
          * Gets the text color of the browser action badge.
          */
-        getBadgeTextColor(details: Details): void;
+        getBadgeTextColor(details: Details): Promise<ColorArray>;
 
         /**
          * Enables the browser action for a tab. By default, browser actions are enabled.

--- a/out/namespaces/captivePortal.d.ts
+++ b/out/namespaces/captivePortal.d.ts
@@ -27,12 +27,12 @@ export namespace CaptivePortal {
         /**
          * Returns the current portal state, one of `unknown`, `not_captive`, `unlocked_portal`, `locked_portal`.
          */
-        getState(): void;
+        getState(): Promise<"unknown" | "not_captive" | "unlocked_portal" | "locked_portal">;
 
         /**
          * Returns the time difference between NOW and the last time a request was completed in milliseconds.
          */
-        getLastChecked(): void;
+        getLastChecked(): Promise<number>;
 
         /**
          * Fired when the captive portal state changes.

--- a/out/namespaces/contextualIdentities.d.ts
+++ b/out/namespaces/contextualIdentities.d.ts
@@ -154,7 +154,7 @@ export namespace ContextualIdentities {
          * @param cookieStoreIds The ID or list of IDs of the contextual identity cookie stores.
          * @param position The position the contextual identity should move to.
          */
-        move(cookieStoreIds: string | string[], position: number): void;
+        move(cookieStoreIds: string | string[], position: number): Promise<void>;
 
         /**
          * Deletes a contextual identity by its cookie Store ID.

--- a/out/namespaces/devtools_panels.d.ts
+++ b/out/namespaces/devtools_panels.d.ts
@@ -80,7 +80,7 @@ export namespace DevtoolsPanels {
          *
          * @param path Relative path of an extension page to display within the sidebar.
          */
-        setPage(path: Manifest.ExtensionURL): void;
+        setPage(path: Manifest.ExtensionURL): Promise<void>;
 
         /**
          * Fired when the sidebar pane becomes visible as a result of user switching to the panel that hosts it.

--- a/out/namespaces/search.d.ts
+++ b/out/namespaces/search.d.ts
@@ -86,7 +86,7 @@ export namespace Search {
         /**
          * Perform a search.
          */
-        search(searchProperties: SearchSearchPropertiesType): void;
+        search(searchProperties: SearchSearchPropertiesType): Promise<void>;
 
         /**
          * Use the chrome.search API to search via the default provider.

--- a/out/namespaces/sidebarAction.d.ts
+++ b/out/namespaces/sidebarAction.d.ts
@@ -167,7 +167,7 @@ export namespace SidebarAction {
         /**
          * Toggles the extension sidebar in the active window.
          */
-        toggle(): void;
+        toggle(): Promise<void>;
 
         /**
          * Checks whether the sidebar action is open.

--- a/out/namespaces/tabs.d.ts
+++ b/out/namespaces/tabs.d.ts
@@ -1160,7 +1160,7 @@ export namespace Tabs {
          *
          * @param tabId The ID of the tab to warm up.
          */
-        warmup(tabId: number): void;
+        warmup(tabId: number): Promise<void>;
 
         /**
          * Closes one or more tabs.

--- a/out/namespaces/userScripts.d.ts
+++ b/out/namespaces/userScripts.d.ts
@@ -186,7 +186,7 @@ export namespace UserScripts {
         /**
          * Unregister a user script registered programmatically
          */
-        unregister(): void;
+        unregister(): Promise<void>;
     }
 
     interface UpdateScriptsItemType extends Omit<RegisteredUserScript, "js"> {


### PR DESCRIPTION
See the below MDN doc for each added fix.

##### `fixes/action.json`
- https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/setBadgeTextColor
- https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/getBadgeTextColor#return_value

##### `fixes/captivePortal.json`
- https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/captivePortal/getState#return_value
- https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/captivePortal/getLastChecked#return_value

##### `fixes/contextualIdentities.json`
- https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/contextualIdentities/move#return_value

##### `fixes/devtools.panels.json`
- https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels/ExtensionSidebarPane/setPage

##### `fixes/search.json`
- https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/search/search#return_value

##### `fixes/sidebarAction.json`
- https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/sidebarAction/toggle#return_value

##### `fixes/tabs.json`
- https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/warmup#return_value

##### `fixes/userScripts.json`
- https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/register
